### PR TITLE
Reduce redundancy in titles

### DIFF
--- a/docs/0.mdx
+++ b/docs/0.mdx
@@ -3,7 +3,7 @@ tags:
   - music
 date created: 2024-11-01
 last reviewed: 2024-11-03
-title: 0 - CD collection
+title: 0
 ---
 
 None

--- a/docs/1.mdx
+++ b/docs/1.mdx
@@ -3,7 +3,7 @@ tags:
   - music
 date created: 2024-11-01
 last reviewed: 2024-11-03
-title: 1 - CD collection
+title: 1
 ---
 
 None

--- a/docs/2.mdx
+++ b/docs/2.mdx
@@ -3,7 +3,7 @@ tags:
   - music
 date created: 2024-11-01
 last reviewed: 2024-11-03
-title: 2 - CD collection
+title: 2
 ---
 
 None

--- a/docs/3.mdx
+++ b/docs/3.mdx
@@ -3,7 +3,7 @@ tags:
   - music
 date created: 2024-11-01
 last reviewed: 2024-11-03
-title: 3 - CD collection
+title: 3
 ---
 
 None

--- a/docs/4.mdx
+++ b/docs/4.mdx
@@ -3,7 +3,7 @@ tags:
   - music
 date created: 2024-11-01
 last reviewed: 2024-11-03
-title: 4 - CD collection
+title: 4
 ---
 
 None

--- a/docs/5.mdx
+++ b/docs/5.mdx
@@ -3,7 +3,7 @@ tags:
   - music
 date created: 2024-11-01
 last reviewed: 2024-11-03
-title: 5 - CD collection
+title: 5
 ---
 
 None

--- a/docs/6.mdx
+++ b/docs/6.mdx
@@ -3,7 +3,7 @@ tags:
   - music
 date created: 2024-11-01
 last reviewed: 2024-11-03
-title: 6 - CD collection
+title: 6
 ---
 
 None

--- a/docs/7.mdx
+++ b/docs/7.mdx
@@ -3,7 +3,7 @@ tags:
   - music
 date created: 2024-11-01
 last reviewed: 2024-11-03
-title: 7 - CD collection
+title: 7
 ---
 
 None

--- a/docs/8.mdx
+++ b/docs/8.mdx
@@ -3,7 +3,7 @@ tags:
   - music
 date created: 2024-11-01
 last reviewed: 2024-11-03
-title: 8 - CD collection
+title: 8
 ---
 
 None

--- a/docs/9.mdx
+++ b/docs/9.mdx
@@ -3,7 +3,7 @@ tags:
   - music
 date created: 2024-11-01
 last reviewed: 2024-11-03
-title: 9 - CD collection
+title: 9
 ---
 
 None

--- a/docs/a.mdx
+++ b/docs/a.mdx
@@ -3,7 +3,7 @@ tags:
   - music
 date created: 2024-11-01
 last reviewed: 2024-11-03
-title: A - CD collection
+title: A
 ---
 
 ## Anderson .Paak

--- a/docs/b.mdx
+++ b/docs/b.mdx
@@ -3,7 +3,7 @@ tags:
   - music
 date created: 2024-11-01
 last reviewed: 2024-11-03
-title: B - CD collection
+title: B
 ---
 
 ## Boris Karloff

--- a/docs/c.mdx
+++ b/docs/c.mdx
@@ -3,7 +3,7 @@ tags:
   - music
 date created: 2024-11-01
 last reviewed: 2024-11-03
-title: C - CD collection
+title: C
 ---
 
 None

--- a/docs/d.mdx
+++ b/docs/d.mdx
@@ -3,7 +3,7 @@ tags:
   - music
 date created: 2024-11-01
 last reviewed: 2024-11-03
-title: D - CD collection
+title: D
 ---
 
 None

--- a/docs/e.mdx
+++ b/docs/e.mdx
@@ -3,7 +3,7 @@ tags:
   - music
 date created: 2024-11-01
 last reviewed: 2024-11-03
-title: E - CD collection
+title: E
 ---
 
 None

--- a/docs/f.mdx
+++ b/docs/f.mdx
@@ -3,7 +3,7 @@ tags:
   - music
 date created: 2024-11-01
 last reviewed: 2024-11-03
-title: F - CD collection
+title: F
 ---
 
 ## The Foreign Exchange

--- a/docs/g.mdx
+++ b/docs/g.mdx
@@ -3,7 +3,7 @@ tags:
   - music
 date created: 2024-11-01
 last reviewed: 2024-11-03
-title: G - CD collection
+title: G
 ---
 
 None

--- a/docs/h.mdx
+++ b/docs/h.mdx
@@ -3,7 +3,7 @@ tags:
   - music
 date created: 2024-11-01
 last reviewed: 2024-11-03
-title: H - CD collection
+title: H
 ---
 
 None

--- a/docs/i.mdx
+++ b/docs/i.mdx
@@ -3,7 +3,7 @@ tags:
   - music
 date created: 2024-11-01
 last reviewed: 2024-11-03
-title: I - CD collection
+title: I
 ---
 
 ## The Internet

--- a/docs/j.mdx
+++ b/docs/j.mdx
@@ -3,7 +3,7 @@ tags:
   - music
 date created: 2024-11-01
 last reviewed: 2024-11-03
-title: J - CD collection
+title: J
 ---
 
 ## Jimmy Haslip

--- a/docs/k.mdx
+++ b/docs/k.mdx
@@ -3,7 +3,7 @@ tags:
   - music
 date created: 2024-11-01
 last reviewed: 2024-11-03
-title: K - CD collection
+title: K
 ---
 
 ## Kid Cudi

--- a/docs/l.mdx
+++ b/docs/l.mdx
@@ -3,7 +3,7 @@ tags:
   - music
 date created: 2024-11-01
 last reviewed: 2024-11-03
-title: L - CD collection
+title: L
 ---
 
 ## Leon Ware

--- a/docs/m.mdx
+++ b/docs/m.mdx
@@ -3,7 +3,7 @@ tags:
   - music
 date created: 2024-11-01
 last reviewed: 2024-11-03
-title: M - CD collection
+title: M
 ---
 
 ## Mariah Carey

--- a/docs/n.mdx
+++ b/docs/n.mdx
@@ -3,7 +3,7 @@ tags:
   - music
 date created: 2024-11-01
 last reviewed: 2024-11-03
-title: N - CD collection
+title: N
 ---
 
 ## Nicolay

--- a/docs/o.mdx
+++ b/docs/o.mdx
@@ -3,7 +3,7 @@ tags:
   - music
 date created: 2024-11-01
 last reviewed: 2024-11-03
-title: O - CD collection
+title: O
 ---
 
 None

--- a/docs/p.mdx
+++ b/docs/p.mdx
@@ -3,7 +3,7 @@ tags:
   - music
 date created: 2024-11-01
 last reviewed: 2024-11-03
-title: P - CD collection
+title: P
 ---
 
 None

--- a/docs/q.mdx
+++ b/docs/q.mdx
@@ -3,7 +3,7 @@ tags:
   - music
 date created: 2024-11-01
 last reviewed: 2024-11-03
-title: Q - CD collection
+title: Q
 ---
 
 

--- a/docs/r.mdx
+++ b/docs/r.mdx
@@ -3,7 +3,7 @@ tags:
   - music
 date created: 2024-11-01
 last reviewed: 2024-11-03
-title: R - CD collection
+title: R
 ---
 
 ## Robert Glasper

--- a/docs/s.mdx
+++ b/docs/s.mdx
@@ -3,7 +3,7 @@ tags:
   - music
 date created: 2024-11-01
 last reviewed: 2024-11-03
-title: S - CD collection
+title: S
 ---
 
 ## Sadao Watanabe

--- a/docs/t.mdx
+++ b/docs/t.mdx
@@ -3,7 +3,7 @@ tags:
   - music
 date created: 2024-11-01
 last reviewed: 2024-11-03
-title: T - CD collection
+title: T
 ---
 
 ## Tower of Power

--- a/docs/u.mdx
+++ b/docs/u.mdx
@@ -3,7 +3,7 @@ tags:
   - music
 date created: 2024-11-01
 last reviewed: 2024-11-03
-title: U - CD collection
+title: U
 ---
 
 None

--- a/docs/v.mdx
+++ b/docs/v.mdx
@@ -3,7 +3,7 @@ tags:
   - music
 date created: 2024-11-01
 last reviewed: 2024-11-03
-title: V - CD collection
+title: V
 ---
 
 ## Vanilla Ice

--- a/docs/w.mdx
+++ b/docs/w.mdx
@@ -3,7 +3,7 @@ tags:
   - music
 date created: 2024-11-01
 last reviewed: 2024-11-03
-title: W - CD collection
+title: W
 ---
 
 ## Wynton Marsalis

--- a/docs/x.mdx
+++ b/docs/x.mdx
@@ -3,7 +3,7 @@ tags:
   - music
 date created: 2024-11-01
 last reviewed: 2024-11-03
-title: X - CD collection
+title: X
 ---
 
 None

--- a/docs/y.mdx
+++ b/docs/y.mdx
@@ -3,7 +3,7 @@ tags:
   - music
 date created: 2024-11-01
 last reviewed: 2024-11-03
-title: Y - CD collection
+title: Y
 ---
 
 ## Yusef Lateef

--- a/docs/z.mdx
+++ b/docs/z.mdx
@@ -3,7 +3,7 @@ tags:
   - music
 date created: 2024-11-01
 last reviewed: 2024-11-03
-title: Z - CD collection
+title: Z
 ---
 
 None


### PR DESCRIPTION
## Description

This PR reduces redundancy in titles since its redundant and should be obvious on the site it’s displayed on. 

## Related issues and/or PRs

N/A

## Changes made

- Removed ` - CD collection` from doc titles.

<h2 id="checklist">Checklist</h2>

The following is a best-effort checklist. If any items in this checklist aren't applicable to this PR, add `N/A` after each item.

### Documentation

- [x] I have updated the side navigation as necessary. `N/A`
- [x] I have updated the documentation to reflect the changes.
- [x] I have documented or updated any remaining open issues linked to this PR in GitHub, Obsidian, etc.

### Build, deploy, and test

- [x] I have merged and published any dependent changes in other PRs.  `N/A`
- [x] I have commented my code, particularly in hard-to-understand areas.  `N/A`
- [x] I have checked that my changes look as expected on a locally built version of the docs site.
- [x] My changes generate no new warnings.
